### PR TITLE
Add support for user credentials

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -6,6 +6,7 @@
 - [`client.config`](#clientconfig)
 - [`client.groups`](#clientgroups)
 - [`client.logger`](#clientlogger)
+- [`client.openUnmanagedServerConnection(serverId: number)`](#clientopenunmanagedserverconnection)
 - [`client.refreshTokens()`](#clientrefreshtokens)
 - [`client.start()`](#clientstart)
 - [`client.subscriptions`](#clientsubscriptions)
@@ -127,6 +128,24 @@ client.logger.error('This error message will be logged.');
 client.logger.warn('This warning message will also be logged.');
 client.logger.info('This info message will NOT be logged due to logVerbosity.');
 client.logger.debug('This debug message will NOT be logged due to logVerbosity.');
+```
+
+## `client.openUnmanagedServerConnection(serverId: number)`
+
+- `serverId` `<number>` the ID of the server (not the server group) you want to connect to
+- Returns: <code>Promise&lt;[ServerConnection](./ServerConnection.md)&gt;</code>
+
+```ts
+try {
+  const connection = await client.openUnmanagedServerConnection(serverId);
+
+  connection.subscribe('PlayerJoined', message => {
+    const { id, username } = message.data.user;
+    connection.send(`player message ${id} "Greetings, ${username}!" 5`);
+  });
+} catch (error) {
+  // your error handling
+}
 ```
 
 ## `client.refreshTokens()`

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -7,12 +7,14 @@
 - [`Config.includedGroups`](#configincludedgroups)
 - [`Config.logVerbosity`](#configlogverbosity)
 - [`Config.maxWorkerConcurrency`](#configmaxworkerconcurrency)
+- [`Config.password`](#configpassword)
 - [`Config.restBaseUrl`](#configrestbaseurl)
 - [`Config.scope`](#configscope)
 - [`Config.serverConnectionRecoveryDelay`](#configserverconnectionrecoverydelay)
 - [`Config.serverHeartbeatTimeout`](#configserverheartbeattimeout)
 - [`Config.supportedServerFleets`](#configsupportedserverfleets)
 - [`Config.tokenUrl`](#configtokenurl)
+- [`Config.username`](#configusername)
 - [`Config.webSocketMigrationHandoverPeriod`](#configwebsocketmigrationhandoverperiod)
 - [`Config.webSocketMigrationInterval`](#configwebsocketmigrationinterval)
 - [`Config.webSocketMigrationRetryDelay`](#configwebsocketmigrationretrydelay)
@@ -27,19 +29,16 @@
 The `Config` object is used to configure a [`Client`](./Client.md).
 
 ```ts
-interface Config {
-  clientId: string;
-  clientSecret: string;
+interface CommonConfig {
   console?: Pick<Console, 'error' | 'warn' | 'info' | 'debug'>;
   excludedGroups?: number[];
   includedGroups?: number[];
   logVerbosity?: Verbosity;
   maxWorkerConcurrency?: number;
   restBaseUrl?: string;
-  scope: Scope[];
   serverConnectionRecoveryDelay?: number;
   serverHeartbeatTimeout?: number;
-  supportedServerFleets: 'att-release' | 'att-quest';
+  supportedServerFleets?: 'att-release' | 'att-quest';
   tokenUrl?: string;
   webSocketMigrationHandoverPeriod?: number;
   webSocketMigrationInterval?: number;
@@ -52,19 +51,34 @@ interface Config {
   webSocketUrl?: string;
   xApiKey?: string;
 }
+
+interface BotConfig extends CommonConfig {
+  clientId: string;
+  clientSecret: string;
+  scope: Scope[];
+}
+
+interface UserConfig extends CommonConfig {
+  username: string;
+  password: string;
+}
+
+type Config = BotConfig | UserConfig;
 ```
 
 ## `Config.clientId`
 
-- `<string>` The bot account's client ID provided to you by Alta.
-- :warning: This configuration option is **required**.
+- `<string>` A bot account's client ID provided to you by Alta.
+- :warning: This configuration option is **required** for bot automation.
+- :warning: This configuration option and [`Config.username`](#configusername) are **mutually exclusive**.
 
 This option sets your [`Client`](./Client.md)'s client ID.
 
 ## `Config.clientSecret`
 
-- `<string>` The bot account's client secret provided to you by Alta.
-- :warning: This configuration option is **required**.
+- `<string>` A bot account's client secret provided to you by Alta.
+- :warning: This configuration option is **required** for bot automation.
+- :warning: This configuration option and [`Config.password`](#configpassword) are **mutually exclusive**.
 - :warning: Never share your client secret with anyone.
 
 This option sets your [`Client`](./Client.md)'s client secret.
@@ -126,6 +140,17 @@ This option changes logging behaviour. The higher `logVerbosity`, the more verbo
 This option configures how many workers are available to handle requests made to Alta services.
 
 :warning: It's not recommended that you change this option. It's been proven that setting this too high will overwhelm Alta services and destabilise your [`Client`](./Client.md)'s connection.
+
+## `Config.password`
+
+- `<string>` An Alta account's password or its SHA512 hexadecimal hash (**preferred**).
+- :warning: This configuration option is **required** when not using [`Config.clientSecret`](#configclientsecret).
+- :warning: This configuration option and [`Config.clientSecret`](#configclientsecret) are **mutually exclusive**.
+- :warning: Never share your account password with anyone.
+
+This option allows [`Client`](./Client.md) to impersonate a user account when interacting with Alta services.
+
+:warning: Most bot automation features are **disabled** when configuring user credentials.
 
 ## `Config.restBaseUrl`
 
@@ -201,6 +226,16 @@ client.on('connect', connection => {
 This option allows you to change where [`Client`](./Client.md) retrieves its JWT.
 
 :warning: It's not recommended that you change this option.
+
+## `Config.username`
+
+- `<string>` An Alta account's username.
+- :warning: This configuration option is **required** when not using [`Config.clientId`](#configclientid).
+- :warning: This configuration option and [`Config.clientId`](#configclientid) are **mutually exclusive**.
+
+This option allows [`Client`](./Client.md) to impersonate a user account when interacting with Alta services.
+
+:warning: Most bot automation features are **disabled** when configuring user credentials.
 
 ## `Config.webSocketMigrationHandoverPeriod`
 

--- a/examples/bot-config.md
+++ b/examples/bot-config.md
@@ -1,6 +1,8 @@
 # Configuring your first bot
 
-You must provide at least `clientId`, `clientSecret` and `scope`, which are provided to you by Alta when creating your bot account.
+You must provide at least either bot credentials—which are provided to you by Alta when creating your bot account—or user credentials.
+
+Bot credentials consist of `clientId`, `clientSecret` and `scope`. User credentials consist of `username` and `password`.
 
 ```ts
 // my-bot-config.js
@@ -9,20 +11,25 @@ export const myBotConfig = {
   clientSecret: 'XXXXXX',
   scope: ['XXXXXX', 'XXXXXX', 'XXXXXX']
 };
-```
 
-```ts
+// my-user-config.js
+export const myUserConfig = {
+  username: 'Ethyn Wyrmbane',
+  password: 'password'
+};
+
+// my-att-bot.js
 import { Client } from 'att-client';
 import { myBotConfig } from './my-bot-config';
 
-const bot = new Client(myBotConfig);
+const client = new Client(myBotConfig);
 
-bot.start();
+client.start();
 ```
 
-## :warning: Storing secrets
+## :warning: Storing passwords and client secrets
 
-You should never share your client ID and secret with anyone! If you're building a bot, be mindful of where you store this information, especially if you'll be committing your source code in an online repository. It's generally best practice to store your secrets in [environment variables](https://www.npmjs.com/package/dotenv), and load them from there:
+You should never share your login details or client ID and secret with anyone! If you're building a bot, be mindful of where you store this information, especially if you'll be committing your source code in an online repository. It's generally best practice to store your secrets in [environment variables](https://www.npmjs.com/package/dotenv), and load them from there:
 
 ```ts
 // my-bot-config.js
@@ -31,6 +38,16 @@ export const myBotConfig = {
   clientSecret: process.env.CLIENT_SECRET ?? ''
   // the rest of your configuration...
 };
+```
+
+If you are configuring and storing user credentials, you should additionally be hashing your password. Alta accepts passwords that have been hashed using the SHA512 algorithm and digested hexadecimally.
+
+```sh
+# unhashed password
+password
+
+# hashed password
+b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86
 ```
 
 ## More configuration options

--- a/src/Api/Api.ts
+++ b/src/Api/Api.ts
@@ -38,108 +38,103 @@ export class Api {
   /**
    * Accepts a group's invite.
    */
-  acceptGroupInvite(groupId: number) {
-    return this.post(Endpoint.AcceptGroupInvite, { groupId });
+  async acceptGroupInvite(groupId: number) {
+    const response = await this.request('POST', Endpoint.AcceptGroupInvite, { groupId });
+
+    return await response.json();
   }
 
   /**
    * Gets a group's information such as name, description, roles and servers.
    */
-  getGroupInfo(groupId: number) {
-    return this.get(Endpoint.GroupInfo, { groupId });
+  async getGroupInfo(groupId: number) {
+    const response = await this.request('GET', Endpoint.GroupInfo, { groupId });
+
+    return await response.json();
   }
 
   /**
    * Gets a group's member's information, such as name, user ID and group role ID.
    */
-  getGroupMember(groupId: number, userId: string) {
-    return this.get(Endpoint.GroupMember, { groupId, userId });
+  async getGroupMember(groupId: number, userId: string) {
+    const response = await this.request('GET', Endpoint.GroupMember, { groupId, userId });
+
+    return await response.json();
   }
 
   /**
    * Gets all groups that this client is a member of. Returns group info and client's
    * membership info for each group.
    */
-  getJoinedGroups() {
-    return this.get(Endpoint.JoinedGroups, undefined, { limit: 1000 });
+  async getJoinedGroups() {
+    const response = await this.request('GET', Endpoint.JoinedGroups, undefined, { limit: 1000 });
+
+    return await response.json();
   }
 
   /**
    * Gets all open group invitations for this client.
    */
-  getPendingGroupInvites() {
-    return this.get(Endpoint.GroupInvites, undefined, { limit: 1000 });
+  async getPendingGroupInvites() {
+    const response = await this.request('GET', Endpoint.GroupInvites, undefined, { limit: 1000 });
+
+    return await response.json();
   }
 
   /**
    * Gets a server's console connection details.
    */
-  getServerConnectionDetails(serverId: number) {
-    return this.post(Endpoint.ServerConsole, { serverId }, undefined, { should_launch: false, ignore_offline: false });
+  async getServerConnectionDetails(serverId: number) {
+    const response = await this.request('POST', Endpoint.ServerConsole, { serverId }, undefined, {
+      should_launch: false,
+      ignore_offline: false
+    });
+
+    return await response.json();
   }
 
   /**
    * Gets a server's information, such as online players and heartbeat status.
    */
-  getServerInfo(serverId: number) {
-    return this.get(Endpoint.ServerInfo, { serverId });
-  }
+  async getServerInfo(serverId: number) {
+    const response = await this.request('GET', Endpoint.ServerInfo, { serverId });
 
-  /**
-   * Sends a GET request to Alta's REST API.
-   */
-  private get<T extends Endpoint>(endpoint: T, params?: Parameters, query?: Parameters) {
-    const url = this.createUrl(endpoint, params, query);
-
-    return this.request('GET', url) as Promise<undefined | ApiResponse<`GET ${T}`>['body']>;
-  }
-
-  /**
-   * Sends a POST request to Alta's REST API.
-   */
-  private post<T extends Endpoint>(
-    endpoint: T,
-    params?: Partial<Parameters>,
-    query?: Parameters,
-    payload?: ApiRequest
-  ) {
-    const url = this.createUrl(endpoint, params, query);
-
-    return this.request('POST', url, payload) as Promise<undefined | ApiResponse<`POST ${T}`>['body']>;
+    return await response.json();
   }
 
   /**
    * Constructs a request to send to Alta's REST API.
    */
-  private async request(method: HttpMethod, url: URL, payload?: ApiRequest): Promise<unknown> {
+  private async request<TMethod extends HttpMethod, TEndpoint extends Endpoint>(
+    method: TMethod,
+    endpoint: TEndpoint,
+    params?: Partial<Parameters>,
+    query?: Parameters,
+    payload?: ApiRequest
+  ): Promise<ApiResponse<TMethod, TEndpoint>> {
     if (typeof this.headers === 'undefined') {
       this.client.logger.error('API is not authorised. Ordering authorisation now.');
       await this.auth();
-      return await this.request(method, url, payload);
+      return await this.request<TMethod, TEndpoint>(method, endpoint, params, query, payload);
     }
+
+    const url = this.createUrl(endpoint, params, query);
 
     this.client.logger.debug(`Requesting ${method} ${url}`, JSON.stringify(payload));
 
-    const response = await fetch(url.toString(), {
+    const response: ApiResponse<TMethod, TEndpoint> = await fetch(url.toString(), {
       method,
       headers: this.headers,
       body: typeof payload === 'undefined' ? null : JSON.stringify(payload)
     });
 
     if (!response.ok) {
-      this.client.logger.error(`${method} ${url} ${payload} responded with ${response.status} ${response.statusText}.`);
-
-      try {
-        const body = await response.json();
-        this.client.logger.error(JSON.stringify(body));
-      } catch (error) {
-        this.client.logger.error(error);
-      }
-
-      return;
+      this.client.logger.error(`${method} ${response.url} responded with ${response.status} ${response.statusText}.`);
+      const body = await response.json();
+      throw new Error(JSON.stringify(body));
     }
 
-    return await response.json();
+    return response;
   }
 
   /**

--- a/src/Api/Api.ts
+++ b/src/Api/Api.ts
@@ -31,7 +31,7 @@ export class Api {
     this.headers = new Headers({
       'Content-Type': 'application/json',
       'x-api-key': this.client.config.xApiKey,
-      'User-Agent': this.client.config.clientId,
+      'User-Agent': this.client.name,
       'Authorization': `Bearer ${this.client.accessToken}`
     });
   }

--- a/src/Api/ApiResponse.ts
+++ b/src/Api/ApiResponse.ts
@@ -9,37 +9,44 @@ import type {
 } from './schemas';
 
 type AcceptGroupInviteResponse = {
-  endpoint: `POST ${Endpoint.AcceptGroupInvite}`;
+  method: 'POST';
+  endpoint: Endpoint.AcceptGroupInvite;
   body: GroupMemberInfo;
 };
 
 type GroupInfoResponse = {
-  endpoint: `GET ${Endpoint.GroupInfo}`;
+  method: 'GET';
+  endpoint: Endpoint.GroupInfo;
   body: GroupInfo;
 };
 
 type GroupInvitesResponse = {
-  endpoint: `GET ${Endpoint.GroupInvites}`;
+  method: 'GET';
+  endpoint: Endpoint.GroupInvites;
   body: InvitedGroupInfo[];
 };
 
 type GroupMemberResponse = {
-  endpoint: `GET ${Endpoint.GroupMember}`;
+  method: 'GET';
+  endpoint: Endpoint.GroupMember;
   body: GroupMemberInfo;
 };
 
 type JoinedGroupsResponse = {
-  endpoint: `GET ${Endpoint.JoinedGroups}`;
+  method: 'GET';
+  endpoint: Endpoint.JoinedGroups;
   body: JoinedGroupInfo[];
 };
 
 type ServerInfoResponse = {
-  endpoint: `GET ${Endpoint.ServerInfo}`;
+  method: 'GET';
+  endpoint: Endpoint.ServerInfo;
   body: ServerInfo;
 };
 
 type ServerConnectionDetailsResponse = {
-  endpoint: `POST ${Endpoint.ServerConsole}`;
+  method: 'POST';
+  endpoint: Endpoint.ServerConsole;
   body: ServerConnectionInfo;
 };
 
@@ -52,4 +59,8 @@ type ApiResponseUnion =
   | ServerConnectionDetailsResponse
   | ServerInfoResponse;
 
-export type ApiResponse<T> = Extract<ApiResponseUnion, { endpoint: T }>;
+type ApiResponseBody<TMethod, TEndpoint> = Extract<ApiResponseUnion, { method: TMethod; endpoint: TEndpoint }>['body'];
+
+export type ApiResponse<TMethod, TEndpoint> = Omit<Response, 'json'> & {
+  json: () => Promise<ApiResponseBody<TMethod, TEndpoint>>;
+};

--- a/src/Api/DecodedToken.ts
+++ b/src/Api/DecodedToken.ts
@@ -1,13 +1,26 @@
 import type { Scope } from '../Client/Config';
 
-export type DecodedToken = {
+type CommonToken = {
   nbf: number;
   exp: number;
   iss: string;
   aud: string[];
+};
+
+type BotToken = CommonToken & {
   client_id: string;
   client_sub: string;
   client_username: string;
   client_bot: 'true' | 'false';
   scope: Scope;
 };
+
+type UserToken = CommonToken & {
+  UserId: string;
+  Username: string;
+  role: string;
+  is_verified: string;
+  Policy: string[];
+};
+
+export type DecodedToken = BotToken | UserToken;

--- a/src/Api/Endpoint.ts
+++ b/src/Api/Endpoint.ts
@@ -5,5 +5,6 @@ export const enum Endpoint {
   GroupMember = '/groups/{groupId}/members/{userId}',
   JoinedGroups = '/groups/joined',
   ServerInfo = '/servers/{serverId}',
-  ServerConsole = '/servers/{serverId}/console'
+  ServerConsole = '/servers/{serverId}/console',
+  Sessions = '/sessions'
 }

--- a/src/Client/Client.ts
+++ b/src/Client/Client.ts
@@ -166,96 +166,105 @@ export class Client extends TypedEmitter<Events> {
     /* Configure access token and decoded token. */
     const decodedToken = await this.refreshTokens();
 
-    const userId = 'client_sub' in decodedToken ? decodedToken.client_sub : decodedToken.UserId;
+    /* Handle bot automation. */
+    if ('client_sub' in decodedToken) {
+      const userId = decodedToken.client_sub;
 
-    /* Initialise subscriptions. */
-    this.logger.info('Subscribing to events.');
-    await this.subscriptions.init();
+      /* Initialise subscriptions. */
+      this.logger.info('Subscribing to events.');
+      await this.subscriptions.init();
 
-    try {
-      /* Subscribe to account messages. */
-      this.logger.debug('Subscribing to account messages.');
+      try {
+        /* Subscribe to account messages. */
+        this.logger.debug('Subscribing to account messages.');
 
-      await Promise.allSettled([
-        /* Subscribe to and handle server group invitation message. */
-        this.subscriptions.subscribe('me-group-invite-create', userId, message => {
-          const { id, name } = message.content;
+        await Promise.allSettled([
+          /* Subscribe to and handle server group invitation message. */
+          this.subscriptions.subscribe('me-group-invite-create', userId, message => {
+            const { id, name } = message.content;
 
-          this.logger.info(`Accepting invite to group ${id} (${name})`);
-          this.api.acceptGroupInvite(id);
-        }),
+            this.logger.info(`Accepting invite to group ${id} (${name})`);
+            this.api.acceptGroupInvite(id);
+          }),
 
-        /* Subscribe to and handle server group joined message. */
-        this.subscriptions.subscribe('me-group-create', userId, async message => {
-          /*
-           * The group info from this message is missing information about
-           * this group's servers and roles. So we'll use the group ID from
-           * this message to fetch more complete information. We'll also
-           * need to get this client's group membership details to determine
-           * group permissions.
-           */
-          const groupId = message.content.id;
-          const groupName = message.content.name;
+          /* Subscribe to and handle server group joined message. */
+          this.subscriptions.subscribe('me-group-create', userId, async message => {
+            /*
+             * The group info from this message is missing information about
+             * this group's servers and roles. So we'll use the group ID from
+             * this message to fetch more complete information. We'll also
+             * need to get this client's group membership details to determine
+             * group permissions.
+             */
+            const groupId = message.content.id;
+            const groupName = message.content.name;
 
-          this.logger.info(`Client was added to group ${groupId} (${groupName}).`);
+            this.logger.info(`Client was added to group ${groupId} (${groupName}).`);
 
-          const group = await this.api.getGroupInfo(groupId);
-          const member = await this.api.getGroupMember(groupId, userId);
+            const [group, member] = await Promise.all([
+              this.api.getGroupInfo(groupId),
+              this.api.getGroupMember(groupId, userId)
+            ]);
 
-          if (typeof group === 'undefined') {
-            this.logger.error(`Couldn't get info for group ${groupId} (${groupName}).`);
-            return;
-          }
+            if (typeof group === 'undefined') {
+              this.logger.error(`Couldn't get info for group ${groupId} (${groupName}).`);
+              return;
+            }
 
-          if (typeof member === 'undefined') {
-            this.logger.error(`Couldn't find group member info for group ${group.id} (${groupName}).`);
-            return;
-          }
+            if (typeof member === 'undefined') {
+              this.logger.error(`Couldn't find group member info for group ${group.id} (${groupName}).`);
+              return;
+            }
 
-          /* Create a new managed group. */
-          this.addGroup(group, member);
-        }),
+            /* Create a new managed group. */
+            this.addGroup(group, member);
+          }),
 
-        /* Subscribe to and handle server group left message. */
-        this.subscriptions.subscribe('me-group-delete', userId, message => {
-          const groupId = message.content.group.id;
-          const groupName = message.content.group.name;
+          /* Subscribe to and handle server group left message. */
+          this.subscriptions.subscribe('me-group-delete', userId, message => {
+            const groupId = message.content.group.id;
+            const groupName = message.content.group.name;
 
-          this.logger.info(`Client was removed from group ${groupId} (${groupName}).`);
-          this.removeGroup(groupId);
-        })
-      ]);
+            this.logger.info(`Client was removed from group ${groupId} (${groupName}).`);
+            this.removeGroup(groupId);
+          })
+        ]);
 
-      /* Manage all joined groups. */
-      const joinedGroups = (await this.api.getJoinedGroups()) ?? [];
+        /* Manage all joined groups. */
+        const joinedGroups = await this.api.getJoinedGroups();
 
-      if (joinedGroups.length > 0) {
-        this.logger.info(`Managing ${joinedGroups.length} group${joinedGroups.length > 1 ? 's' : ''}.`);
+        if (joinedGroups.length > 0) {
+          this.logger.info(`Managing ${joinedGroups.length} group${joinedGroups.length > 1 ? 's' : ''}.`);
 
-        const tasks = joinedGroups.map(
-          ({ group, member }) =>
-            () =>
-              this.addGroup(group, member)
-        );
+          const tasks = joinedGroups.map(
+            ({ group, member }) =>
+              () =>
+                this.addGroup(group, member)
+          );
 
-        const workers = new Workers(this.config.maxWorkerConcurrency);
-        await workers.do(tasks);
+          const workers = new Workers(this.config.maxWorkerConcurrency);
+          await workers.do(tasks);
+        }
+
+        /* Accept pending group invites. */
+        const invites = await this.api.getPendingGroupInvites();
+
+        if (invites.length > 0) {
+          this.logger.info(`Accepting ${invites.length} pending group invite${invites.length > 1 ? 's' : ''}.`);
+
+          const tasks = invites.map(invite => () => this.api.acceptGroupInvite(invite.id));
+
+          const workers = new Workers(this.config.maxWorkerConcurrency);
+          await workers.do(tasks);
+        }
+      } catch (error) {
+        this.logger.error((error as Error).message);
+        return;
       }
-
-      /* Accept pending group invites. */
-      const invites = (await this.api.getPendingGroupInvites()) ?? [];
-
-      if (invites.length > 0) {
-        this.logger.info(`Accepting ${invites.length} pending group invite${invites.length > 1 ? 's' : ''}.`);
-
-        const tasks = invites.map(invite => () => this.api.acceptGroupInvite(invite.id));
-
-        const workers = new Workers(this.config.maxWorkerConcurrency);
-        await workers.do(tasks);
-      }
-    } catch (error) {
-      this.logger.error((error as Error).message);
-      return;
+    } else {
+      this.logger.warn(
+        `You have configured this client with user credentials, so it will operate with most bot automation features disabled. To enable, please provide bot credentials instead.`
+      );
     }
 
     this.readyState = ReadyState.Ready;

--- a/src/Client/Client.ts
+++ b/src/Client/Client.ts
@@ -9,6 +9,7 @@ import { Logger } from '../Logger';
 import { Subscriptions } from '../Subscriptions';
 import { DEFAULTS, MAX_WORKER_CONCURRENCY_WARNING } from '../constants';
 import { Workers } from '../Workers';
+import pkg from '../../package.json';
 
 interface Events {
   connect: (serverConnection: ServerConnection) => void;
@@ -23,6 +24,7 @@ export class Client extends TypedEmitter<Events> {
   config: Required<Config>;
   groups: Groups;
   logger: Logger;
+  name: string;
   subscriptions: Subscriptions;
 
   private decodedToken?: DecodedToken;
@@ -110,6 +112,7 @@ export class Client extends TypedEmitter<Events> {
     this.api = new Api(this);
     this.groups = {};
     this.initialised = false;
+    this.name = `${pkg.name} v${pkg.version}`;
     this.subscriptions = new Subscriptions(this);
   }
 
@@ -266,7 +269,7 @@ export class Client extends TypedEmitter<Events> {
       'Host': 'accounts.townshiptale.com',
       'Content-Type': 'application/x-www-form-urlencoded',
       'Content-Length': bodyString.length.toString(),
-      'User-Agent': this.config.clientId
+      'User-Agent': this.name
     };
     this.logger.debug('Configured access token request headers.', JSON.stringify(headers));
 

--- a/src/Client/Client.ts
+++ b/src/Client/Client.ts
@@ -8,9 +8,8 @@ import { Api, DecodedToken, Endpoint } from '../Api';
 import { Group } from '../Group';
 import { Logger, Verbosity } from '../Logger';
 import { Subscriptions } from '../Subscriptions';
-import { DEFAULTS, MAX_WORKER_CONCURRENCY_WARNING } from '../constants';
 import { Workers } from '../Workers';
-import pkg from '../../package.json';
+import { DEFAULTS, MAX_WORKER_CONCURRENCY_WARNING, PACKAGE } from '../constants';
 
 interface Events {
   connect: (serverConnection: ServerConnection) => void;
@@ -144,7 +143,7 @@ export class Client extends TypedEmitter<Events> {
     /* Initialise internals. */
     this.api = new Api(this);
     this.groups = {};
-    this.name = `${pkg.name} v${pkg.version}`;
+    this.name = `${PACKAGE.name} v${PACKAGE.version}`;
     this.readyState = ReadyState.Stopped;
     this.subscriptions = new Subscriptions(this);
   }

--- a/src/Client/Config.ts
+++ b/src/Client/Config.ts
@@ -16,16 +16,13 @@ export type Scope =
   | 'ws.group_members'
   | 'ws.group_servers';
 
-export interface Config {
-  clientId: string;
-  clientSecret: string;
+interface CommonConfig {
   console?: Pick<Console, 'error' | 'warn' | 'info' | 'debug'>;
   excludedGroups?: number[];
   includedGroups?: number[];
   logVerbosity?: Verbosity;
   maxWorkerConcurrency?: number;
   restBaseUrl?: string;
-  scope: Scope[];
   serverConnectionRecoveryDelay?: number;
   serverHeartbeatTimeout?: number;
   supportedServerFleets?: ServerFleet[];
@@ -41,3 +38,16 @@ export interface Config {
   webSocketUrl?: string;
   xApiKey?: string;
 }
+
+interface BotConfig extends CommonConfig {
+  clientId: string;
+  clientSecret: string;
+  scope: Scope[];
+}
+
+interface UserConfig extends CommonConfig {
+  username: string;
+  password: string;
+}
+
+export type Config = BotConfig | UserConfig;

--- a/src/Group/Group.ts
+++ b/src/Group/Group.ts
@@ -1,8 +1,5 @@
-import type { Api } from '../Api';
 import type { GroupInfo, GroupMemberInfo, ServerInfo } from '../Api/schemas';
 import type { Client } from '../Client';
-import type { Logger } from '../Logger';
-import type { Subscriptions } from '../Subscriptions';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { Server } from '../Server';
 
@@ -27,17 +24,11 @@ export class Group extends TypedEmitter<Events> {
   roles: Role[];
   servers: Servers;
 
-  private api: Api;
-  private logger: Logger;
-  private subscriptions: Subscriptions;
   private userId: number;
 
   constructor(client: Client, group: GroupInfo, member: GroupMemberInfo) {
     super();
 
-    this.logger = client.logger;
-
-    this.api = client.api;
     this.client = client;
     this.description = group.description ?? '';
     this.id = group.id;
@@ -45,11 +36,10 @@ export class Group extends TypedEmitter<Events> {
     this.permissions = this.getPermissions(group, member);
     this.roles = [];
     this.servers = {};
-    this.subscriptions = client.subscriptions;
     this.userId = member.user_id;
 
     if (!this.permissions.includes('Console')) {
-      this.logger.warn(
+      this.client.logger.warn(
         `This client does not have 'Console' permissions for group ${this.id} (${this.name}).`,
         JSON.stringify(this.permissions)
       );
@@ -68,12 +58,12 @@ export class Group extends TypedEmitter<Events> {
       /**
        * Subscribe to group updates, such as changes to servers, roles and permissions.
        */
-      this.subscriptions.subscribe('group-update', this.id.toString(), async message => {
+      this.client.subscriptions.subscribe('group-update', this.id.toString(), async message => {
         const group = message.content;
-        const member = await this.api.getGroupMember(this.id, this.userId.toString());
+        const member = await this.client.api.getGroupMember(this.id, this.userId.toString());
 
         if (typeof member === 'undefined') {
-          this.logger.error(`Couldn't find group member info for group ${group.id} (${this.name}).`);
+          this.client.logger.error(`Couldn't find group member info for group ${group.id} (${this.name}).`);
           return;
         }
 
@@ -83,16 +73,16 @@ export class Group extends TypedEmitter<Events> {
       /**
        * Subscribe to group member changes, such as assigned role and permissions.
        */
-      this.subscriptions.subscribe('group-member-update', this.id.toString(), async message => {
+      this.client.subscriptions.subscribe('group-member-update', this.id.toString(), async message => {
         const member = message.content;
 
         if (member.user_id !== this.userId) return;
 
-        this.logger.info(`Membership updated for group ${this.id}.`);
-        const group = await this.api.getGroupInfo(this.id);
+        this.client.logger.info(`Membership updated for group ${this.id}.`);
+        const group = await this.client.api.getGroupInfo(this.id);
 
         if (typeof group === 'undefined') {
-          this.logger.error(`Couldn't get info for group ${this.id} (${this.name}).`);
+          this.client.logger.error(`Couldn't get info for group ${this.id} (${this.name}).`);
           return;
         }
 
@@ -103,10 +93,10 @@ export class Group extends TypedEmitter<Events> {
        * Subscribe to server status changes, such as number of players and online or
        * offline state.
        */
-      this.subscriptions.subscribe('group-server-status', this.id.toString(), async message => {
+      this.client.subscriptions.subscribe('group-server-status', this.id.toString(), async message => {
         const status = message.content;
 
-        this.logger.debug(`Status updated for server ${status.id} (${status.name}).`, JSON.stringify(status));
+        this.client.logger.debug(`Status updated for server ${status.id} (${status.name}).`, JSON.stringify(status));
         this.manageServerConnection(status);
       }),
 
@@ -118,9 +108,9 @@ export class Group extends TypedEmitter<Events> {
        * it's possible that in the future any single group can have more than one
        * server that may be created by players themselves.
        */
-      this.subscriptions.subscribe('group-server-create', this.id.toString(), _unstableMessage => {
+      this.client.subscriptions.subscribe('group-server-create', this.id.toString(), _unstableMessage => {
         /* ⚠️ This code is untested because I can't create new servers. */
-        this.logger.warn(
+        this.client.logger.warn(
           'Client is running untested group-server-create code in Group.ts.',
           JSON.stringify(_unstableMessage)
         );
@@ -138,9 +128,9 @@ export class Group extends TypedEmitter<Events> {
        * it's possible that in the future any single group can have more than one
        * server that may be deleted by players themselves.
        */
-      this.subscriptions.subscribe('group-server-delete', this.id.toString(), _unstableMessage => {
+      this.client.subscriptions.subscribe('group-server-delete', this.id.toString(), _unstableMessage => {
         /* ⚠️ This code is untested because I can't delete servers. */
-        this.logger.warn(
+        this.client.logger.warn(
           'Client is running untested group-server-delete code in Group.ts.',
           JSON.stringify(_unstableMessage)
         );
@@ -165,11 +155,11 @@ export class Group extends TypedEmitter<Events> {
    * Updates a server with new server info.
    */
   private async updateServer(serverId: number) {
-    this.logger.debug(`Updating info for server ${serverId}.`);
-    const status = await this.api.getServerInfo(serverId);
+    this.client.logger.debug(`Updating info for server ${serverId}.`);
+    const status = await this.client.api.getServerInfo(serverId);
 
     if (typeof status === 'undefined') {
-      this.logger.error(`Couldn't get status for server ${serverId} (${this.name}).`);
+      this.client.logger.error(`Couldn't get status for server ${serverId} (${this.name}).`);
       return;
     }
 
@@ -199,9 +189,9 @@ export class Group extends TypedEmitter<Events> {
     this.permissions = this.getPermissions(group, member);
 
     if (!previousPermissions.includes('Console') && this.permissions.includes('Console')) {
-      this.logger.info(`Client gained console access to servers in group ${this.id} (${this.name}).`);
+      this.client.logger.info(`Client gained console access to servers in group ${this.id} (${this.name}).`);
     } else if (previousPermissions.includes('Console') && !this.permissions.includes('Console')) {
-      this.logger.info(`Client lost console access to servers in group ${this.id} (${this.name}).`);
+      this.client.logger.info(`Client lost console access to servers in group ${this.id} (${this.name}).`);
     }
 
     await this.updateServers();
@@ -227,7 +217,7 @@ export class Group extends TypedEmitter<Events> {
     const server = this.servers[serverId];
 
     if (typeof server === 'undefined') {
-      this.logger.error(`Server ${serverId} not found in group ${this.id} (${this.name}).`);
+      this.client.logger.error(`Server ${serverId} not found in group ${this.id} (${this.name}).`);
       return;
     }
 
@@ -252,7 +242,7 @@ export class Group extends TypedEmitter<Events> {
    * Starts managing all servers listed in a given group info.
    */
   private addServers(group: GroupInfo) {
-    this.logger.debug(`Adding all servers for group ${this.id} (${this.name}).`);
+    this.client.logger.debug(`Adding all servers for group ${this.id} (${this.name}).`);
 
     for (const server of group.servers ?? []) {
       this.addServer(server.id);
@@ -263,17 +253,17 @@ export class Group extends TypedEmitter<Events> {
    * Starts managing the given server.
    */
   private async addServer(serverId: number) {
-    this.logger.debug(`Adding server ${serverId} (${this.name}).`);
+    this.client.logger.debug(`Adding server ${serverId} (${this.name}).`);
 
     if (Object.keys(this.servers).map(Number).includes(serverId)) {
-      this.logger.error(`Can't add server ${serverId} (${this.name}) more than once.`);
+      this.client.logger.error(`Can't add server ${serverId} (${this.name}) more than once.`);
       return;
     }
 
-    const server = await this.api.getServerInfo(serverId);
+    const server = await this.client.api.getServerInfo(serverId);
 
     if (typeof server === 'undefined') {
-      this.logger.error(`Couldn't get info for server ${serverId} (${this.name}).`);
+      this.client.logger.error(`Couldn't get info for server ${serverId} (${this.name}).`);
       return;
     }
 
@@ -289,7 +279,7 @@ export class Group extends TypedEmitter<Events> {
    * Removes all managed servers from this group.
    */
   private removeServers() {
-    this.logger.debug(`Removing all servers from group ${this.id} (${this.name}).`);
+    this.client.logger.debug(`Removing all servers from group ${this.id} (${this.name}).`);
 
     for (const server of Object.values(this.servers)) {
       this.removeServer(server.id);
@@ -300,12 +290,12 @@ export class Group extends TypedEmitter<Events> {
    * Removes the given managed server from this group.
    */
   private removeServer(serverId: number) {
-    this.logger.debug(`Removing server ${serverId} (${this.name}).`);
+    this.client.logger.debug(`Removing server ${serverId} (${this.name}).`);
 
     const server = this.servers[serverId];
 
     if (typeof server === 'undefined') {
-      this.logger.error(`Can't remove an unmanaged server with ID ${serverId} (${this.name}).`);
+      this.client.logger.error(`Can't remove an unmanaged server with ID ${serverId} (${this.name}).`);
       return;
     }
 
@@ -320,11 +310,11 @@ export class Group extends TypedEmitter<Events> {
     this.removeServers();
 
     await Promise.all([
-      this.subscriptions.unsubscribe('group-update', this.id.toString()),
-      this.subscriptions.unsubscribe('group-server-create', this.id.toString()),
-      this.subscriptions.unsubscribe('group-server-delete', this.id.toString()),
-      this.subscriptions.unsubscribe('group-server-status', this.id.toString()),
-      this.subscriptions.unsubscribe('group-member-update', this.id.toString())
+      this.client.subscriptions.unsubscribe('group-update', this.id.toString()),
+      this.client.subscriptions.unsubscribe('group-server-create', this.id.toString()),
+      this.client.subscriptions.unsubscribe('group-server-delete', this.id.toString()),
+      this.client.subscriptions.unsubscribe('group-server-status', this.id.toString()),
+      this.client.subscriptions.unsubscribe('group-member-update', this.id.toString())
     ]);
   }
 }

--- a/src/Group/Group.ts
+++ b/src/Group/Group.ts
@@ -12,6 +12,7 @@ type Role = {
 type Servers = Record<number, Server>;
 
 interface Events {
+  'server-add': (server: Server) => void;
   update: (group: Group) => void;
 }
 
@@ -271,10 +272,14 @@ export class Group extends TypedEmitter<Events> {
       return;
     }
 
+    const managedServer = new Server(this, server);
+
     this.servers = {
       ...this.servers,
-      [serverId]: new Server(this, server)
+      [serverId]: managedServer
     } as Servers;
+
+    this.emit('server-add', managedServer);
 
     this.manageServerConnection(server);
   }

--- a/src/Group/Group.ts
+++ b/src/Group/Group.ts
@@ -230,7 +230,11 @@ export class Group extends TypedEmitter<Events> {
     const hasOnlinePlayers = status.online_players.length > 0;
 
     if (server.status === 'disconnected' && mayConnect && isServerOnline && hasOnlinePlayers) {
-      await server.connect();
+      try {
+        await server.connect();
+      } catch (error) {
+        this.client.logger.error(`Couldn't connect to server ${serverId}: ${(error as Error).message}`);
+      }
     } else if (server.status !== 'disconnected' && (!mayConnect || !isServerOnline)) {
       server.disconnect();
     }

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -50,7 +50,7 @@ export class Server extends TypedEmitter<Events> {
 
     const serverConnectionInfo = await this.group.client.api.getServerConnectionDetails(this.id);
 
-    if (typeof serverConnectionInfo === 'undefined') {
+    if ('ok' in serverConnectionInfo) {
       this.group.client.logger.error(`Couldn't get connection details for server ${this.id} (${this.name}).`);
       return;
     }

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -9,6 +9,7 @@ type Player = {
 };
 
 interface Events {
+  connect: (serverConnection: ServerConnection) => void;
   update: (server: Server) => void;
 }
 

--- a/src/Subscriptions/Subscriptions.ts
+++ b/src/Subscriptions/Subscriptions.ts
@@ -153,7 +153,7 @@ export class Subscriptions {
         const headers = {
           'Content-Type': 'application/json',
           'x-api-key': this.client.config.xApiKey,
-          'User-Agent': this.client.config.clientId,
+          'User-Agent': this.client.name,
           'Authorization': `Bearer ${accessToken}`
         };
         this.logger.debug('Configured WebSocket headers.', JSON.stringify(headers));
@@ -186,7 +186,7 @@ export class Subscriptions {
    */
   private ping(ws: WebSocket) {
     this.logger.debug('Pinging WebSocket.');
-    ws.ping(this.client.config.clientId);
+    ws.ping(this.client.name);
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ const WEBSOCKET_URL = 'wss://5wx2mgoj95.execute-api.ap-southeast-2.amazonaws.com
 
 const X_API_KEY = '2l6aQGoNes8EHb94qMhqQ5m2iaiOM9666oDTPORf';
 
-export const DEFAULTS: Required<Omit<Config, 'clientId' | 'clientSecret' | 'scope'>> = {
+export const DEFAULTS: Required<Omit<Config, 'clientId' | 'clientSecret' | 'scope' | 'username' | 'password'>> = {
   console: console,
   excludedGroups: [],
   includedGroups: [],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,9 @@
 import type { ServerFleet } from './Api';
 import type { Config } from './Client/Config';
 import { Verbosity } from './Logger';
+import packageJson from '../package.json';
+
+export const PACKAGE = packageJson;
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist",
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es2021"


### PR DESCRIPTION
## Context

Users are able to interact with Alta services using their Alta account credentials. Currently, `att-client` only supports bot credentials, making it impossible to use with user credentials. There are some use cases for using a user account rather than a bot account. Bot accounts also take notoriously long to be created by Alta staff.

This PR adds support for configuring `att-client` with user credentials and allowing a server console connection to be opened while authenticated as that user.

## Changes

* Adds `username` and `password` configuration options.
* Adds `openUnmanagedServerConnection` method to `Client` class.
* Updates error handling and function return types of several internals to support new workflow.
* Prevents bot automation features when user credentials are configured.
* Updates documentation.